### PR TITLE
Feature/upload board image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@
 .DS_Store
 /vendor/bundle
 venv/node_modules
+
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "rails-i18n"
 
 gem "draper"
 
+gem "carrierwave"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,13 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (3.0.7)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      ssrf_filter (~> 1.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -119,11 +126,20 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -148,6 +164,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.1)
     msgpack (1.7.2)
@@ -282,6 +299,9 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     securerandom (0.3.1)
@@ -305,6 +325,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.2)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -347,6 +368,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  carrierwave
   cssbundling-rails
   debug
   draper

--- a/app/controllers/boards_controller.rb
+++ b/app/controllers/boards_controller.rb
@@ -20,6 +20,6 @@ class BoardsController < ApplicationController
   private
 
   def board_params
-    params.require(:board).permit(:title, :body)
+    params.require(:board).permit(:title, :body, :board_image, :board_image_cache)
   end
 end

--- a/app/models/board.rb
+++ b/app/models/board.rb
@@ -3,4 +3,6 @@ class Board < ApplicationRecord
   validates :body, presence: true, length: { maximum: 255 }
 
   belongs_to :user
+
+  mount_uploader :board_image, BoardImageUploader
 end

--- a/app/uploaders/board_image_uploader.rb
+++ b/app/uploaders/board_image_uploader.rb
@@ -1,0 +1,53 @@
+class BoardImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+  def default_url
+    'board_placeholder.png'
+  end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg"
+  # end
+end

--- a/app/uploaders/board_image_uploader.rb
+++ b/app/uploaders/board_image_uploader.rb
@@ -21,7 +21,7 @@ class BoardImageUploader < CarrierWave::Uploader::Base
   #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   # end
   def default_url
-    'board_placeholder.png'
+    "board_placeholder.png"
   end
 
   # Process files as they are uploaded:

--- a/app/views/boards/_board.html.erb
+++ b/app/views/boards/_board.html.erb
@@ -2,7 +2,7 @@
   <div>
     <%= link_to '#', id: "board-id-#{board.id}" do %>
       <figure class="image-full">
-        <%= image_tag "board_placeholder.png", class: "w-32 h-32 object-contain rounded-md shadow-xl" %>
+        <%= image_tag board.board_image_url, class: "w-32 h-32 object-contain rounded-md shadow-xl" %>
       </figure>
     <% end %>
   </div>

--- a/app/views/boards/new.html.erb
+++ b/app/views/boards/new.html.erb
@@ -11,7 +11,11 @@
         <%= f.label :body, class: "block text-lg font-medium mb-1" %>
         <%= f.text_field :body, class: "w-full border border-gray-300 rounded-md shadow-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-blue-500", rows: 10 %>
       </div>
-      <%= f.submit nil, class: "bg-yellow-900 hover:bg-yellow-800 text-white rounded px-4 py-2" %>
+      <div>
+        <%= f.file_field :board_image, class: "file-input file-input-bordered file-input-warning w-full max-w-xs", accept: 'image/*' %>
+        <%= f.hidden_field :board_image_cache %>
+      </div>
+      <%= f.submit nil, class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "application.tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
-  </head>
 
   <body>
     <% if logged_in? %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-neutral">
   <div class="flex-1">
-    <a class="btn btn-ghost text-xl text-accent">CHOCOLATE DUCK</a>
+    <%= link_to 'CHOCOLATE DUCK', '/', class: 'btn btn-ghost text-xl text-accent' %>
   </div>
   <div class="flex-none">
     <div class="dropdown dropdown-hover dropdown-end">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,6 +1,6 @@
 <div class="navbar bg-neutral">
   <div class="flex-1">
-    <a class="btn btn-ghost text-xl text-accent">CHOCOLATE DUCK</a>
+    <%= link_to 'CHOCOLATE DUCK', '/', class: 'btn btn-ghost text-xl text-accent' %>
   </div>
   <div class="flex-none">
     <div class="dropdown dropdown-hover dropdown-end">

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -5,7 +5,7 @@
       <p class="py-6 mb-8">
         チョコレート、アヒル… ちゃいろときいろのものを投稿してみよう！
       </p>
-      <button class="btn btn-primary mb-6">はじめる</button>
+      <%= link_to 'はじめる', boards_path, class: 'btn btn-primary mb-6' %>
     </div>
   </div>
 </div>

--- a/db/migrate/20240903093638_add_board_image_to_boards.rb
+++ b/db/migrate/20240903093638_add_board_image_to_boards.rb
@@ -1,0 +1,5 @@
+class AddBoardImageToBoards < ActiveRecord::Migration[7.2]
+  def change
+    add_column :boards, :board_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_09_03_014250) do
+ActiveRecord::Schema[7.2].define(version: 2024_09_03_093638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_09_03_014250) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "board_image"
     t.index ["user_id"], name: "index_boards_on_user_id"
   end
 


### PR DESCRIPTION
## 概要
画像アップロード
### 内容
- gem carrierwaveを導入
- board_imgaeカラムを追加
- BoardImageUploaderを生成し、デフォルト画像とファイル形式を設定
- ローカルでアップロードした画像をプッシュしないよう設定
- 画像アップロードのボタンを追加
- ヘッダーからトップページへのリンクを追加